### PR TITLE
Fix HMac validation error on large buffers

### DIFF
--- a/src/main/java/org/cryptonode/jncryptor/AES256JNCryptorInputStream.java
+++ b/src/main/java/org/cryptonode/jncryptor/AES256JNCryptorInputStream.java
@@ -297,7 +297,6 @@ public class AES256JNCryptorInputStream extends InputStream {
 
       // Have we reached the end of the stream?
       int c = pushbackInputStream.read();
-      rawOutputStream.reset(); // don't want to actually keep this byte
       if (c == END_OF_STREAM) {
         handleEndOfStream();
       } else {

--- a/src/test/java/org/cryptonode/jncryptor/AES256JNCryptorInputStreamTest.java
+++ b/src/test/java/org/cryptonode/jncryptor/AES256JNCryptorInputStreamTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Random;
@@ -93,7 +94,41 @@ public class AES256JNCryptorInputStreamTest {
   }
 
   /**
-   * Test reading of mismatched data (e.g. encrypte using keys, decrypted with
+   * Test reading using read(byte[]) method, with larger data amount and buffers,
+   * testing Issue #6.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testUsingReadByteArrayLargeBufferIssue6() throws Exception {
+    byte[] plaintext = getRandomBytes(50000);
+
+    final String password = "Testing1234";
+
+    JNCryptor cryptor = new AES256JNCryptor();
+    byte[] data = cryptor.encryptData(plaintext, password.toCharArray());
+
+    InputStream in = new AES256JNCryptorInputStream(new ByteArrayInputStream(
+        data), password.toCharArray());
+
+    try {
+      byte[] buffer = new byte[16383];
+      ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+      int len;
+      do {
+        len = in.read(buffer);
+        if (len > 0)
+          outStream.write(buffer, 0, len);
+      } while (len >= 0);
+      byte[] result = outStream.toByteArray();
+      assertArrayEquals(plaintext, result);
+    } finally {
+      in.close();
+    }
+  }
+
+  /**
+   * Test reading of mismatched data (e.g. encrypted using keys, decrypted with
    * password).
    * 
    * @throws Exception


### PR DESCRIPTION
Fix issue #6 I think (Mac validation fails); for me (running on MacOS X) the bug would happen with any larger amount of data (more than a 512 bytes, probably due to a CipherInputStream buffer).

When doing the lookahead byte, it is working on the higher-level InputStream, and that operation does not affect the lower-level rawOutputStrem, so there is no need to call reset() on it.  Until the last block, the rawOutputStream would never actually get written to until that one-byte read() call (presumably due to buffers in higher-level streams in the chain), and therefore the reset() call would clear it out without ever updating the Mac, meaning that no bytes from the encrypted stream were ever written to the Mac until the (partial) last block, meaning that (of course) the Mac verification failed.

I added a test case which encrypts 50k or so which demonstrates the bug (though it would probably manifest on 1k in my case).  The behavior might be different on different platforms, as it's probably dependent on the CipherInputStream implementation (and perhaps the Cipher provider).  Simply removing the reset() call lets the new unit test pass.
