### PR TITLE
add streaming support for encryption / decryption + tests

### DIFF
--- a/src/main/java/org/cryptonode/jncryptor/AES256JNCryptor.java
+++ b/src/main/java/org/cryptonode/jncryptor/AES256JNCryptor.java
@@ -78,13 +78,14 @@ import javax.crypto.spec.SecretKeySpec;
  */
 public class AES256JNCryptor implements JNCryptor {
 
-  private static final String AES_CIPHER_ALGORITHM = "AES/CBC/PKCS5Padding";
-  private static final String HMAC_ALGORITHM = "HmacSHA256";
-  private static final String AES_NAME = "AES";
-  private static final String KEY_DERIVATION_ALGORITHM = "PBKDF2WithHmacSHA1";
-  private static final int PBKDF_DEFAULT_ITERATIONS = 10000;
-  private static final int VERSION = 3;
-  private static final int AES_256_KEY_SIZE = 256 / 8;
+  static final String AES_CIPHER_ALGORITHM = "AES/CBC/PKCS5Padding";
+  static final String HMAC_ALGORITHM = "HmacSHA256";
+  static final String AES_NAME = "AES";
+  static final String KEY_DERIVATION_ALGORITHM = "PBKDF2WithHmacSHA1";
+  static final int PBKDF_DEFAULT_ITERATIONS = 10000;
+  static final int VERSION = 3;
+  static final byte[] VERSION_OPTIONS = new byte[] { VERSION, 1 };
+  static final int AES_256_KEY_SIZE = 256 / 8;
   private static final int AES_BLOCK_SIZE = 16;
 
   // Salt length exposed as package private to aid unit testing

--- a/src/main/java/org/cryptonode/jncryptor/AES256JNCryptorInputStream.java
+++ b/src/main/java/org/cryptonode/jncryptor/AES256JNCryptorInputStream.java
@@ -1,0 +1,134 @@
+package org.cryptonode.jncryptor;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+
+import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
+import javax.crypto.Mac;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+
+
+/**
+ * Perform password based decryption, based on <a href="https://github.com/RNCryptor/RNCryptor-Spec/blob/master/RNCryptor-Spec-v3.md">v3 of the RNCryptor spec</a>.
+ * 
+ * The last 32 bytes of the stream is the HMAC. This stream will not return the HMAC bytes
+ * when reading, and will instead verify the HMAC when it is read and throw an {@link IOException}
+ * if it fails the check.
+ * @author michaelyin
+ *
+ */
+public class AES256JNCryptorInputStream extends InputStream {
+
+  private static final int ENCRYPTION_KEY_LENGTH = AES256JNCryptor.AES_256_KEY_SIZE * 8;
+  private final CipherInputStream stream;
+
+  /**
+   * Create a decrypting input stream by wrapping an existing input stream containing the
+   * encrypted data.
+   * @param inputStream the input stream that has been encrypted to the RNCryptor v3 spec
+   * @param password the password to decrypt with
+   * @throws IllegalStateException if the file is encrypted with something other than version 3
+   * @throws IOException failed to read RNCryptor header
+   * @throws NoSuchAlgorithmException specific AES encryption algorithm not supported
+   * @throws InvalidKeySpecException error with the key
+   * @throws InvalidKeyException error with the key
+   * @throws NoSuchPaddingException encryption padding not supported
+   * @throws InvalidAlgorithmParameterException problem decrypting stream
+   */
+  public AES256JNCryptorInputStream(InputStream inputStream, char[] password)
+      throws IllegalStateException, IOException, NoSuchAlgorithmException, InvalidKeySpecException,
+      InvalidKeyException, NoSuchPaddingException, InvalidAlgorithmParameterException {
+    Validate.notNull(password, "Password cannot be null.");
+    Validate.isTrue(password.length > 0, "Password cannot be empty.");
+
+    /*
+     * Byte:     |    0    |    1    |      2-9       |  10-17   | 18-33 | <-      ...     -> | n-32 - n |
+     * Contents: | version | options | encryptionSalt | HMACSalt |  IV   | ... ciphertext ... |   HMAC   |
+     */
+    int version = inputStream.read();
+    if (version != AES256JNCryptor.VERSION) {
+      throw new IllegalStateException("Invalid encrypted header version. Expected 3, got " + version);
+    }
+    // options byte, assume pw encryption
+    inputStream.read();
+    byte[] salt = new byte[8];
+    byte[] hmacSalt = new byte[8];
+    byte[] iv = new byte[16];
+    inputStream.read(salt);
+    inputStream.read(hmacSalt);
+    inputStream.read(iv);
+    final SecretKeyFactory keyFactory = SecretKeyFactory.getInstance(AES256JNCryptor.KEY_DERIVATION_ALGORITHM);
+    final KeySpec hmacKeySpec = new PBEKeySpec(password, hmacSalt, AES256JNCryptor.PBKDF_DEFAULT_ITERATIONS, ENCRYPTION_KEY_LENGTH);
+    final SecretKey hmacKey = keyFactory.generateSecret(hmacKeySpec);
+    final Mac mac = Mac.getInstance(AES256JNCryptor.HMAC_ALGORITHM);
+    mac.init(hmacKey);
+    mac.update(AES256JNCryptor.VERSION_OPTIONS);
+    mac.update(salt);
+    mac.update(hmacSalt);
+    mac.update(iv);
+
+    final HmacTrailingInputStream formatStream = new HmacTrailingInputStream(inputStream, mac);
+    final KeySpec keySpec = new PBEKeySpec(password, salt, AES256JNCryptor.PBKDF_DEFAULT_ITERATIONS, ENCRYPTION_KEY_LENGTH);
+    Cipher cipher = Cipher.getInstance(AES256JNCryptor.AES_CIPHER_ALGORITHM);
+    IvParameterSpec ivParams = new IvParameterSpec(iv);
+    cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(keyFactory.generateSecret(keySpec).getEncoded(), AES256JNCryptor.AES_NAME), ivParams);
+
+    stream = new CipherInputStream(formatStream, cipher);
+  }
+  
+  @Override
+  public int read() throws IOException {
+    return stream.read();
+  }
+  
+  @Override
+  public int read(byte[] b) throws IOException {
+    return stream.read(b);
+  }
+  
+  @Override
+  public synchronized void mark(int readlimit) {
+    stream.mark(readlimit);
+  }
+  
+  @Override
+  public int available() throws IOException {
+    return stream.available();
+  }
+  
+  @Override
+  public void close() throws IOException {
+    stream.close();
+  }
+  
+  @Override
+  public boolean markSupported() {
+    return stream.markSupported();
+  }
+  
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    return stream.read(b, off, len);
+  }
+  
+  @Override
+  public synchronized void reset() throws IOException {
+    stream.reset();
+  }
+  
+  @Override
+  public long skip(long n) throws IOException {
+    return stream.skip(n);
+  }
+}

--- a/src/main/java/org/cryptonode/jncryptor/AES256JNCryptorOutputStream.java
+++ b/src/main/java/org/cryptonode/jncryptor/AES256JNCryptorOutputStream.java
@@ -1,0 +1,153 @@
+package org.cryptonode.jncryptor;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.Mac;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * A wrapper stream that encrypts according to the <a href="https://github.com/RNCryptor/RNCryptor-Spec/blob/master/RNCryptor-Spec-v3.md">RNCryptor v3 spec</a>.
+ * Since HMAC requires all of the encrypted data to be written first, it is written when the stream
+ * is closed. If you don't want to close the stream yet, you can alternatively call
+ * {@link #finish()} to make sure the HMAC is written after writing all the encrypted data.
+ * @author michaelyin
+ *
+ */
+public class AES256JNCryptorOutputStream extends FilterOutputStream {
+
+  private static final int ENCRYPTION_KEY_LENGTH = AES256JNCryptor.AES_256_KEY_SIZE * 8;
+
+  private final Cipher cipher;
+  private final Mac mac;
+  private boolean finished = false;
+
+  /**
+   * Creates an output stream that outputs in the RNCryptor v3 spec into the given output stream.
+   * @param outputStream the stream to receive encrypted data
+   * @param password password to encrypt with
+   * @return a stream that will encrypt data and send it to the wrapped stream.
+   * @throws IOException
+   */
+  public AES256JNCryptorOutputStream(OutputStream out, char[] password) throws IOException {
+    this(out, password, null, null, null);
+  }
+
+  /**
+   * Used for testing to inject salts instead of using a random salts.
+   */
+  // visible for testing
+  AES256JNCryptorOutputStream(OutputStream out, final char[] password, byte[] salt, byte[] hmacSalt,
+      byte[] iv) throws IOException {
+    super(out);
+    Validate.notNull(password, "Password cannot be null.");
+    Validate.isTrue(password.length > 0, "Password cannot be empty.");
+
+    final SecureRandom random = new SecureRandom();
+    if (salt == null || hmacSalt == null || iv == null) {
+      salt = new byte[8];
+      hmacSalt = new byte[8];
+      iv = new byte[16];
+      random.nextBytes(salt);
+      random.nextBytes(hmacSalt);
+      random.nextBytes(iv);
+    }
+
+    try {
+      final SecretKeyFactory keyFactory = SecretKeyFactory.getInstance(AES256JNCryptor.KEY_DERIVATION_ALGORITHM);
+      cipher = Cipher.getInstance(AES256JNCryptor.AES_CIPHER_ALGORITHM);
+      final KeySpec keySpec = new PBEKeySpec(password, salt, AES256JNCryptor.PBKDF_DEFAULT_ITERATIONS, ENCRYPTION_KEY_LENGTH);
+      final SecretKey key = new SecretKeySpec(keyFactory.generateSecret(keySpec).getEncoded(), AES256JNCryptor.AES_NAME);
+
+      final KeySpec hmacKeySpec = new PBEKeySpec(password, hmacSalt, AES256JNCryptor.PBKDF_DEFAULT_ITERATIONS, ENCRYPTION_KEY_LENGTH);
+      final SecretKey hmacKey = keyFactory.generateSecret(hmacKeySpec);
+
+      final IvParameterSpec ivParams = new IvParameterSpec(iv);
+      cipher.init(Cipher.ENCRYPT_MODE, key, ivParams);
+
+      mac = Mac.getInstance(AES256JNCryptor.HMAC_ALGORITHM);
+      mac.init(hmacKey);
+
+      mac.update(AES256JNCryptor.VERSION_OPTIONS);
+      out.write(AES256JNCryptor.VERSION_OPTIONS);
+      mac.update(salt);
+      out.write(salt);
+      mac.update(hmacSalt);
+      out.write(hmacSalt);
+      mac.update(iv);
+      out.write(iv);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("This device does not support encrpytion algorithm. Cannot decrypt.", e);
+    } catch (NoSuchPaddingException e) {
+      throw new IllegalStateException("This device does not support the expected encryption padding. Cannot decrypt.", e);
+    } catch (InvalidKeyException e) {
+      throw new IllegalStateException("Error with key. Cannot decrypt.", e);
+    } catch (InvalidKeySpecException e) {
+      throw new IllegalStateException("Error with key. Cannot decrypt.", e);
+    } catch (InvalidAlgorithmParameterException e) {
+      throw new IllegalStateException("Problem decrypting stream.", e);
+    }
+  }
+
+  @Override
+  public void write(byte[] buffer, int offset, int length) throws IOException {
+    if (length == 0) {
+      return;
+    }
+    byte[] result = cipher.update(buffer, offset, length);
+    if (result != null) {
+      mac.update(result);
+      out.write(result);
+    }
+  }
+
+  // all writes get funneled into the write(buffer, offset, length) form
+  @Override
+  public void write(int oneByte) throws IOException {
+    final byte[] buffer = new byte[1];
+    buffer[0] = (byte) (oneByte & 0xff);
+    write(buffer);
+  }
+
+  /**
+   * Finish the encryption without closing the underlying stream.
+   */
+  public void finish() throws IOException {
+    if (!finished) {
+      try {
+        byte[] finalBytes = cipher.doFinal();
+        out.write(finalBytes);
+        byte[] hmac = mac.doFinal(finalBytes);
+        out.write(hmac);
+        out.flush();
+      } catch (IllegalBlockSizeException e) {
+        throw new IOException(e);
+      } catch (BadPaddingException e) {
+        throw new IOException(e);
+      } finally {
+        finished = true;
+      }
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    finish();
+    super.close();
+  }
+}

--- a/src/main/java/org/cryptonode/jncryptor/HmacTrailingInputStream.java
+++ b/src/main/java/org/cryptonode/jncryptor/HmacTrailingInputStream.java
@@ -1,0 +1,153 @@
+package org.cryptonode.jncryptor;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PushbackInputStream;
+
+import javax.crypto.Mac;
+
+/**
+ * Helper class that processes and verifies the HMAC once it has been found (as well as not
+ * including it for the client's requested input bytes).
+ * @author michaelyin
+ *
+ */
+class HmacTrailingInputStream extends PushbackInputStream {
+
+    static final int HMAC_SIZE = 32;
+    private static final int BUFFER_SIZE = 8192;
+    private final byte[] hmac = new byte[HMAC_SIZE];
+    private final byte[] buf = new byte[BUFFER_SIZE];
+    private final Mac mac;
+    private boolean haveChecked = false;
+
+    /**
+     * @param inputStream the RNCryptor stream starting at the ciphertext block
+     * @param mac initialized mac to compute HMAC to verify with stream's HMAC.
+     */
+    public HmacTrailingInputStream(InputStream inputStream, Mac mac) {
+      super(inputStream, HMAC_SIZE + 1);
+      this.mac = mac;
+    }
+
+    @Override
+    public int read() throws IOException {
+        int read = 0;
+        while (read < hmac.length) {
+            int extraRead = super.read(hmac, read, hmac.length - read);
+            if (extraRead == -1) {
+                checkHmac();
+                return -1;
+            }
+            read += extraRead;
+        }
+        int endCheck = super.read();
+        if (endCheck == -1) {
+            // eof
+            checkHmac();
+            return -1;
+        }
+        unread(endCheck);
+        unread(hmac, 0, read);
+        read = super.read();
+        mac.update((byte) read);
+        return read;
+    }
+
+    // constant time equality check
+    private void checkHmac() throws IOException {
+        if (haveChecked ) {
+            return;
+        }
+        byte[] computedHmac = mac.doFinal();
+
+        final int expectedLength = hmac.length;
+        final int computedLength = computedHmac.length;
+
+        int result = computedHmac.length - hmac.length;
+
+        for (int i = 0; i < computedLength; i++) {
+            result |= hmac[i % expectedLength] ^ computedHmac[i];
+        }
+        haveChecked = true;
+        if (result != 0) {
+            throw new IOException("HMAC validation failed!");
+        }
+    }
+
+    // read into an internal buffer first to check if we're @ the hmac block,
+    // then copy into the read buffer once we determine it's clean
+    @Override
+    public int read(byte[] buffer, int byteOffset, int byteCount) throws IOException {
+        int read = 0;
+        while (read < hmac.length) {
+            int extraRead = super.read(hmac, read, hmac.length - read);
+            if (extraRead == -1) {
+                checkHmac();
+                return -1;
+            }
+            read += extraRead;
+        }
+        int endCheck = super.read();
+        if (endCheck == -1) {
+            // eof
+            checkHmac();
+            return -1;
+        }
+        unread(endCheck);
+        unread(hmac, 0, read);
+
+        read = 0;
+        while (byteCount > 0) {
+            int readLength = buf.length;
+            if (byteCount + hmac.length < buf.length) {
+                readLength = byteCount + hmac.length;
+            }
+            int curRead = 0;
+            // ensure we've retrieved at least hmac.length
+            while (curRead < hmac.length) {
+                int extraRead = super.read(buf, curRead, readLength - curRead);
+                if (extraRead == -1) {
+                    throw new IOException("Unexpectedly hit end of stream before encountering HMAC.");
+                }
+                curRead += extraRead;
+            }
+            endCheck = super.read();
+            if (endCheck == -1) {
+                // hit end of stream, extract HMAC, copy the rest to client buffer
+                curRead -= hmac.length;
+                System.arraycopy(buf, curRead, hmac, 0, hmac.length);
+                System.arraycopy(buf, 0, buffer, byteOffset, curRead);
+                mac.update(buffer, byteOffset, read + curRead);
+                checkHmac();
+                return read + curRead;
+            } else {
+                // unread the extra hmac checking bytes, copy the rest to client buffer
+                unread(endCheck);
+                curRead -= hmac.length;
+                System.arraycopy(buf, curRead, hmac, 0, hmac.length);
+                unread(hmac);
+                System.arraycopy(buf, 0, buffer, byteOffset, curRead);
+                mac.update(buffer, byteOffset, curRead);
+            }
+            byteOffset += curRead;
+            byteCount -= curRead;
+            read += curRead;
+        }
+        return read;
+    }
+
+    @Override
+    public long skip(long byteCount) throws IOException {
+        long skippedBytes = 0;
+        byte[] buf = new byte[BUFFER_SIZE];
+        while (byteCount > 0) {
+            if (byteCount < buf.length) {
+                return read(buf, 0, (int) byteCount) + skippedBytes;
+            }
+            skippedBytes += read(buf, 0, buf.length);
+            byteCount -= buf.length;
+        }
+        return skippedBytes;
+    }
+}

--- a/src/test/java/org/cryptonode/jncryptor/AES256JNCryptorInputStreamTest.java
+++ b/src/test/java/org/cryptonode/jncryptor/AES256JNCryptorInputStreamTest.java
@@ -1,0 +1,55 @@
+package org.cryptonode.jncryptor;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.Random;
+import java.util.UUID;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class AES256JNCryptorInputStreamTest {
+
+    private static final int MAX_SIZE = 2 * 1024 * 1024;
+    private static final int TEST_ITERATIONS = 100;
+    private final Random random = new Random();
+    private final JNCryptor cryptor = new AES256JNCryptor();
+
+    /**
+     * Tests decryption of a random byte array of max length {@value #MAX_SIZE}, with a random
+     * UUID as a password. Encryption is done by the {@link JNCryptor} reference implementation.
+     */
+    @Test
+    public void testRandomDecryption() throws Exception {
+        byte[] startData = new byte[random.nextInt(MAX_SIZE) + 1];
+        random.nextBytes(startData);
+        char[] password = UUID.randomUUID().toString().toCharArray();
+        byte[] ciphertext = cryptor.encryptData(startData, password);
+
+        InputStream is = new AES256JNCryptorInputStream(new ByteArrayInputStream(ciphertext), password);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int len;
+        while ((len = is.read(buffer)) != -1) {
+            baos.write(buffer, 0, len);
+        }
+        is.close();
+
+        byte[] result = baos.toByteArray();
+        assertArrayEquals("Decrypted data doesn't match encrypted data!", startData, result);
+    }
+
+    @Ignore("heavy test")
+    @Test
+    public void testDecryptionALot() throws Exception {
+        for (int i = 0; i < TEST_ITERATIONS; i++) {
+            System.out.print(i + ", ");
+            testRandomDecryption();
+        }
+        System.out.println();
+    }
+}

--- a/src/test/java/org/cryptonode/jncryptor/AES256JNCryptorOutputStreamTest.java
+++ b/src/test/java/org/cryptonode/jncryptor/AES256JNCryptorOutputStreamTest.java
@@ -1,0 +1,47 @@
+package org.cryptonode.jncryptor;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Random;
+import java.util.UUID;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class AES256JNCryptorOutputStreamTest {
+
+  private static final int MAX_SIZE = 2 * 1024 * 1024;
+  private static final int TEST_ITERATIONS = 100;
+  private final Random random = new Random();
+  private final JNCryptor cryptor = new AES256JNCryptor();
+
+
+  @Test
+  public void testRandomEncryption() throws IOException, CryptorException {
+    byte[] startData = new byte[random.nextInt(MAX_SIZE) + 1];
+    random.nextBytes(startData);
+    char[] password = UUID.randomUUID().toString().toCharArray();
+
+    ByteArrayOutputStream encryptedStream = new ByteArrayOutputStream();
+    AES256JNCryptorOutputStream os = new AES256JNCryptorOutputStream(encryptedStream, password);
+    os.write(startData);
+    os.flush();
+    os.close();
+
+    byte[] cipherText = encryptedStream.toByteArray();
+    byte[] plainText = cryptor.decryptData(cipherText, password);
+    assertArrayEquals("Decrypted data doesn't match original data!", startData, plainText);
+  }
+
+  @Ignore("heavy test")
+  @Test
+  public void testEncryptionALot() throws IOException, CryptorException {
+    for (int i = 0; i < TEST_ITERATIONS; i++) {
+      System.out.print(i + ", ");
+      testRandomEncryption();
+    }
+    System.out.println();
+  }
+}


### PR DESCRIPTION
implementation of issue #3

I've only briefly looked at the streaming branch already here, but I had to implement both decrypting and encrypting streams for an Android project that had to match iOS RNCryptor implementation, so I just started from scratch and came up with this implementation.

For decrypting, it uses a [PushbackInputStream](http://docs.oracle.com/javase/7/docs/api/java/io/PushbackInputStream.html) to probe for the end of the stream while simultaneously storing the HMAC provided by the stream, then doing a constant-time check of the provided HMAC with a computed HMAC.

For encrypting, it is fairly straightforward. It writes the header to the wrapped output stream and allows a finishing step if the client doesn't want to close the stream after writing the cipher text.
